### PR TITLE
Add Floodgate form-based authentication flow for Bedrock players

### DIFF
--- a/src/main/java/net/elytrium/limboauth/LimboAuth.java
+++ b/src/main/java/net/elytrium/limboauth/LimboAuth.java
@@ -120,6 +120,7 @@ import org.bstats.charts.SingleLineChart;
 import org.bstats.velocity.Metrics;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.geysermc.cumulus.form.util.FormBuilder;
 import org.slf4j.Logger;
 
 @Plugin(
@@ -534,6 +535,20 @@ public class LimboAuth {
     String username = player.getUsername();
     String lowercaseUsername = username.toLowerCase(Locale.ROOT);
     this.cachedAuthChecks.put(lowercaseUsername, new CachedSessionUser(System.currentTimeMillis(), player.getRemoteAddress().getAddress(), username));
+  }
+
+  public boolean isFloodgatePlayer(Player player) {
+    return this.floodgateApi != null && this.floodgateApi.isFloodgatePlayer(player.getUniqueId());
+  }
+
+  public boolean canUseFloodgateForms(Player player) {
+    return this.floodgateApi != null
+        && Settings.IMP.MAIN.FLOODGATE_FORMS.ENABLED
+        && this.floodgateApi.isFloodgatePlayer(player.getUniqueId());
+  }
+
+  public boolean sendFloodgateForm(Player player, FormBuilder<?, ?, ?> builder) {
+    return this.floodgateApi != null && this.floodgateApi.sendForm(player.getUniqueId(), builder);
   }
 
   public void removePlayerFromCache(String username) {

--- a/src/main/java/net/elytrium/limboauth/Settings.java
+++ b/src/main/java/net/elytrium/limboauth/Settings.java
@@ -112,6 +112,47 @@ public class Settings extends YamlConfig {
     public boolean TOTP_NEED_PASSWORD = true;
     public boolean REGISTER_NEED_REPEAT_PASSWORD = true;
     public boolean CHANGE_PASSWORD_NEED_OLD_PASSWORD = true;
+
+    @Create
+    public MAIN.FLOODGATE_FORMS FLOODGATE_FORMS;
+
+    @Comment("Settings for Floodgate Bedrock authentication forms.")
+    public static class FLOODGATE_FORMS {
+
+      public boolean ENABLED = true;
+
+      @Comment("Title shown on the registration form for Floodgate players.")
+      public String REGISTER_TITLE = "LimboAuth Registration";
+      public String REGISTER_TEXT = "Create a password to protect your account.";
+      public String REGISTER_PASSWORD_LABEL = "Password";
+      public String REGISTER_PASSWORD_PLACEHOLDER = "Enter password";
+      public String REGISTER_REPEAT_LABEL = "Repeat password";
+      public String REGISTER_REPEAT_PLACEHOLDER = "Repeat password";
+      public String REGISTER_ERROR_PASSWORD_MISMATCH = "§cThe passwords do not match.";
+      public String REGISTER_ERROR_PASSWORD_TOO_SHORT = "§cThe password is too short.";
+      public String REGISTER_ERROR_PASSWORD_TOO_LONG = "§cThe password is too long.";
+      public String REGISTER_ERROR_PASSWORD_UNSAFE = "§cThe password is unsafe.";
+      public String REGISTER_ERROR_PASSWORD_EMPTY = "§cThe password cannot be empty.";
+
+      @Comment("Title shown on the login form for Floodgate players.")
+      public String LOGIN_TITLE = "LimboAuth Login";
+      public String LOGIN_TEXT = "Enter your password to continue.";
+      public String LOGIN_PASSWORD_LABEL = "Password";
+      public String LOGIN_PASSWORD_PLACEHOLDER = "Enter password";
+      public String LOGIN_ERROR_PASSWORD_EMPTY = "§cThe password cannot be empty.";
+      public String LOGIN_ERROR_WRONG_PASSWORD = "§cIncorrect password. Attempts left: {0}";
+
+      @Comment("Title shown on the 2FA form for Floodgate players.")
+      public String TOTP_TITLE = "Two-factor authentication";
+      public String TOTP_TEXT = "Enter the 2FA code from your authenticator app.";
+      public String TOTP_CODE_LABEL = "2FA code";
+      public String TOTP_PLACEHOLDER = "000000";
+      public String TOTP_ERROR_EMPTY = "§cThe 2FA code cannot be empty.";
+      public String TOTP_ERROR_INVALID = "§cThe 2FA code is invalid.";
+
+      public String FORM_CLOSED = "§cYou must finish the form to authenticate.";
+    }
+
     @Comment("Used in unregister and premium commands.")
     public String CONFIRM_KEYWORD = "confirm";
     @Comment("This prefix will be added to offline mode players nickname")

--- a/src/main/java/net/elytrium/limboauth/floodgate/FloodgateApiHolder.java
+++ b/src/main/java/net/elytrium/limboauth/floodgate/FloodgateApiHolder.java
@@ -18,6 +18,7 @@
 package net.elytrium.limboauth.floodgate;
 
 import java.util.UUID;
+import org.geysermc.cumulus.form.util.FormBuilder;
 import org.geysermc.floodgate.api.FloodgateApi;
 
 /**
@@ -37,5 +38,9 @@ public class FloodgateApiHolder {
 
   public int getPrefixLength() {
     return this.floodgateApi.getPlayerPrefix().length();
+  }
+
+  public boolean sendForm(UUID uuid, FormBuilder<?, ?, ?> builder) {
+    return this.floodgateApi.sendForm(uuid, builder);
   }
 }

--- a/src/main/java/net/elytrium/limboauth/handler/AuthSessionHandler.java
+++ b/src/main/java/net/elytrium/limboauth/handler/AuthSessionHandler.java
@@ -53,6 +53,9 @@ import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.Title;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.geysermc.cumulus.form.CustomForm;
+import org.geysermc.cumulus.response.CustomFormResponse;
+import org.geysermc.cumulus.response.result.FormResponseResult;
 
 public class AuthSessionHandler implements LimboSessionHandler {
 
@@ -105,6 +108,8 @@ public class AuthSessionHandler implements LimboSessionHandler {
   );
   private final boolean loginOnlyByMod = Settings.IMP.MAIN.MOD.ENABLED && Settings.IMP.MAIN.MOD.LOGIN_ONLY_BY_MOD;
 
+  private boolean useFloodgateForms;
+
   @Nullable
   private RegisteredPlayer playerInfo;
 
@@ -121,6 +126,7 @@ public class AuthSessionHandler implements LimboSessionHandler {
     this.proxyPlayer = proxyPlayer;
     this.plugin = plugin;
     this.playerInfo = playerInfo;
+    this.useFloodgateForms = !this.loginOnlyByMod && this.plugin.canUseFloodgateForms(proxyPlayer);
   }
 
   @Override
@@ -199,6 +205,11 @@ public class AuthSessionHandler implements LimboSessionHandler {
   @Override
   public void onChat(String message) {
     if (this.loginOnlyByMod) {
+      return;
+    }
+
+    if (this.useFloodgateForms) {
+      this.showFloodgateForm(null);
       return;
     }
 
@@ -351,6 +362,11 @@ public class AuthSessionHandler implements LimboSessionHandler {
   }
 
   private void sendMessage(boolean sendTitle) {
+    if (this.useFloodgateForms) {
+      this.showFloodgateForm(null);
+      return;
+    }
+
     if (this.totpState) {
       this.proxyPlayer.sendMessage(totp);
       if (sendTitle && totpTitle != null) {
@@ -447,6 +463,194 @@ public class AuthSessionHandler implements LimboSessionHandler {
 
     this.plugin.cacheAuthUser(this.proxyPlayer);
     this.player.disconnect();
+  }
+
+  private void showFloodgateForm(@Nullable String errorMessage) {
+    if (!this.useFloodgateForms) {
+      return;
+    }
+
+    Settings.MAIN.FLOODGATE_FORMS forms = Settings.IMP.MAIN.FLOODGATE_FORMS;
+    FloodgateStage stage = this.getFloodgateStage();
+    CustomForm.Builder builder = CustomForm.builder();
+
+    switch (stage) {
+      case REGISTER: {
+        builder.title(forms.REGISTER_TITLE);
+        builder.label(this.composeFloodgateText(forms.REGISTER_TEXT, errorMessage));
+        builder.input(forms.REGISTER_PASSWORD_LABEL, forms.REGISTER_PASSWORD_PLACEHOLDER, "");
+        if (Settings.IMP.MAIN.REGISTER_NEED_REPEAT_PASSWORD) {
+          builder.input(forms.REGISTER_REPEAT_LABEL, forms.REGISTER_REPEAT_PLACEHOLDER, "");
+        }
+        builder.validResultHandler((form, response) -> this.handleFloodgateRegisterResponse(response));
+        break;
+      }
+      case LOGIN: {
+        builder.title(forms.LOGIN_TITLE);
+        builder.label(this.composeFloodgateText(forms.LOGIN_TEXT, errorMessage));
+        builder.input(forms.LOGIN_PASSWORD_LABEL, forms.LOGIN_PASSWORD_PLACEHOLDER, "");
+        builder.validResultHandler((form, response) -> this.handleFloodgateLoginResponse(response));
+        break;
+      }
+      case TOTP: {
+        builder.title(forms.TOTP_TITLE);
+        builder.label(this.composeFloodgateText(forms.TOTP_TEXT, errorMessage));
+        builder.input(forms.TOTP_CODE_LABEL, forms.TOTP_PLACEHOLDER, "");
+        builder.validResultHandler((form, response) -> this.handleFloodgateTotpResponse(response));
+        break;
+      }
+      default:
+        break;
+    }
+
+    builder.closedOrInvalidResultHandler((form, result) -> this.handleFloodgateClosed(result));
+
+    if (!this.plugin.sendFloodgateForm(this.proxyPlayer, builder)) {
+      this.useFloodgateForms = false;
+      this.sendMessage(true);
+    }
+  }
+
+  private void handleFloodgateClosed(@Nullable FormResponseResult<CustomFormResponse> result) {
+    if (!this.useFloodgateForms) {
+      return;
+    }
+
+    if (result == null || result.isClosed() || result.isInvalid()) {
+      this.showFloodgateForm(Settings.IMP.MAIN.FLOODGATE_FORMS.FORM_CLOSED);
+    }
+  }
+
+  private void handleFloodgateRegisterResponse(CustomFormResponse response) {
+    String password = this.normalizeFloodgateInput(response.asInput());
+    String repeat = null;
+    if (Settings.IMP.MAIN.REGISTER_NEED_REPEAT_PASSWORD) {
+      repeat = this.normalizeFloodgateInput(response.asInput());
+    }
+
+    String validationError = this.validateFloodgateRegisterPassword(password, repeat);
+    if (validationError != null) {
+      this.showFloodgateForm(validationError);
+      return;
+    }
+
+    this.saveTempPassword(password);
+    RegisteredPlayer registeredPlayer = new RegisteredPlayer(this.proxyPlayer).setPassword(password);
+
+    try {
+      this.playerDao.create(registeredPlayer);
+      this.playerInfo = registeredPlayer;
+    } catch (SQLException e) {
+      this.proxyPlayer.disconnect(databaseErrorKick);
+      throw new SQLRuntimeException(e);
+    }
+
+    this.proxyPlayer.sendMessage(registerSuccessful);
+    if (registerSuccessfulTitle != null) {
+      this.proxyPlayer.showTitle(registerSuccessfulTitle);
+    }
+
+    this.plugin.getServer().getEventManager()
+        .fire(new PostRegisterEvent(this::finishAuth, this.player, this.playerInfo, this.tempPassword))
+        .thenAcceptAsync(this::finishAuth);
+  }
+
+  private void handleFloodgateLoginResponse(CustomFormResponse response) {
+    if (this.playerInfo == null) {
+      return;
+    }
+
+    Settings.MAIN.FLOODGATE_FORMS forms = Settings.IMP.MAIN.FLOODGATE_FORMS;
+    String password = this.normalizeFloodgateInput(response.asInput());
+
+    if (password.isEmpty()) {
+      this.showFloodgateForm(forms.LOGIN_ERROR_PASSWORD_EMPTY);
+      return;
+    }
+
+    this.saveTempPassword(password);
+
+    if (checkPassword(password, this.playerInfo, this.playerDao)) {
+      if (this.playerInfo.getTotpToken().isEmpty()) {
+        this.finishLogin();
+      } else {
+        this.totpState = true;
+        this.sendMessage(true);
+      }
+    } else if (--this.attempts != 0) {
+      this.showFloodgateForm(MessageFormat.format(forms.LOGIN_ERROR_WRONG_PASSWORD, this.attempts));
+      this.checkBruteforceAttempts();
+    } else {
+      this.proxyPlayer.disconnect(loginWrongPasswordKick);
+    }
+  }
+
+  private void handleFloodgateTotpResponse(CustomFormResponse response) {
+    if (this.playerInfo == null) {
+      return;
+    }
+
+    Settings.MAIN.FLOODGATE_FORMS forms = Settings.IMP.MAIN.FLOODGATE_FORMS;
+    String code = this.normalizeFloodgateInput(response.asInput());
+
+    if (code.isEmpty()) {
+      this.showFloodgateForm(forms.TOTP_ERROR_EMPTY);
+      return;
+    }
+
+    if (TOTP_CODE_VERIFIER.isValidCode(this.playerInfo.getTotpToken(), code)) {
+      this.finishLogin();
+    } else {
+      this.checkBruteforceAttempts();
+      this.showFloodgateForm(forms.TOTP_ERROR_INVALID);
+    }
+  }
+
+  private @Nullable String validateFloodgateRegisterPassword(String password, @Nullable String repeat) {
+    Settings.MAIN.FLOODGATE_FORMS forms = Settings.IMP.MAIN.FLOODGATE_FORMS;
+
+    if (password.isEmpty()) {
+      return forms.REGISTER_ERROR_PASSWORD_EMPTY;
+    }
+
+    if (Settings.IMP.MAIN.REGISTER_NEED_REPEAT_PASSWORD && (repeat == null || !password.equals(repeat))) {
+      return forms.REGISTER_ERROR_PASSWORD_MISMATCH;
+    }
+
+    int length = password.length();
+    if (length > Settings.IMP.MAIN.MAX_PASSWORD_LENGTH) {
+      return forms.REGISTER_ERROR_PASSWORD_TOO_LONG;
+    }
+    if (length < Settings.IMP.MAIN.MIN_PASSWORD_LENGTH) {
+      return forms.REGISTER_ERROR_PASSWORD_TOO_SHORT;
+    }
+    if (Settings.IMP.MAIN.CHECK_PASSWORD_STRENGTH && this.plugin.getUnsafePasswords().contains(password)) {
+      return forms.REGISTER_ERROR_PASSWORD_UNSAFE;
+    }
+
+    return null;
+  }
+
+  private FloodgateStage getFloodgateStage() {
+    if (this.totpState && this.playerInfo != null) {
+      return FloodgateStage.TOTP;
+    }
+    return this.playerInfo == null ? FloodgateStage.REGISTER : FloodgateStage.LOGIN;
+  }
+
+  private String composeFloodgateText(String base, @Nullable String errorMessage) {
+    if (errorMessage == null || errorMessage.isEmpty()) {
+      return base;
+    }
+    return base + "\n\n" + errorMessage;
+  }
+
+  private String normalizeFloodgateInput(@Nullable String value) {
+    if (value == null) {
+      return "";
+    }
+
+    return value.trim();
   }
 
   public static void reload() {
@@ -578,6 +782,12 @@ public class AuthSessionHandler implements LimboSessionHandler {
     return HASHER.hashToString(Settings.IMP.MAIN.BCRYPT_COST, password.toCharArray());
   }
 
+
+  private enum FloodgateStage {
+    REGISTER,
+    LOGIN,
+    TOTP
+  }
 
   private enum Command {
 


### PR DESCRIPTION
## Summary
- add configurable settings to drive Floodgate Bedrock authentication forms
- expose helpers for sending Floodgate forms and detecting Floodgate players
- implement form-based registration, login, and TOTP handling for Floodgate users

## Testing
- `./gradlew check`


------
https://chatgpt.com/codex/tasks/task_e_68c8502bff9883328a6bfab0fac01a47