### PR TITLE
Add Floodgate forms for Bedrock authentication

### DIFF
--- a/src/main/java/net/elytrium/limboauth/LimboAuth.java
+++ b/src/main/java/net/elytrium/limboauth/LimboAuth.java
@@ -959,6 +959,10 @@ public class LimboAuth {
     return this.playerDao;
   }
 
+  public static Logger getLogger() {
+    return LOGGER;
+  }
+
   private static void setLogger(Logger logger) {
     LOGGER = logger;
   }

--- a/src/main/java/net/elytrium/limboauth/LimboAuth.java
+++ b/src/main/java/net/elytrium/limboauth/LimboAuth.java
@@ -671,7 +671,7 @@ public class LimboAuth {
       }
       case NORMAL:
       default: {
-        this.authServer.spawnPlayer(player, new AuthSessionHandler(this.playerDao, player, this, registeredPlayer));
+        this.authServer.spawnPlayer(player, new AuthSessionHandler(this.playerDao, player, this, registeredPlayer, this.floodgateApi));
         break;
       }
     }

--- a/src/main/java/net/elytrium/limboauth/Settings.java
+++ b/src/main/java/net/elytrium/limboauth/Settings.java
@@ -432,6 +432,13 @@ public class Settings extends YamlConfig {
       @Comment(value = "Can be empty.", at = Comment.At.SAME_LINE)
       public String LOGIN_SUCCESSFUL_SUBTITLE = "&aSuccessfully logged in!";
 
+      @Comment("Bedrock login form")
+      public String LOGIN_FORM_TITLE = "Authorization";
+      public String LOGIN_FORM_DESCRIPTION = "Please, enter your password. Attempts left: {0}";
+      public String LOGIN_FORM_PASSWORD_PROMPT = "Password";
+      public String LOGIN_FORM_PASSWORD_PLACEHOLDER = "";
+      public String LOGIN_FORM_ERROR_WRONG_PASSWORD = "Wrong password. Attempts left: {0}";
+
       @Comment("Or if register-need-repeat-password set to false remove the \"<repeat password>\" part.")
       public String REGISTER = "{PRFX} Please, register using &6/register <password> <repeat password>";
       public String REGISTER_DIFFERENT_PASSWORDS = "{PRFX} &cThe entered passwords differ from each other!";
@@ -447,6 +454,18 @@ public class Settings extends YamlConfig {
       public String REGISTER_SUCCESSFUL_TITLE = "{PRFX}";
       @Comment(value = "Can be empty.", at = Comment.At.SAME_LINE)
       public String REGISTER_SUCCESSFUL_SUBTITLE = "&aSuccessfully registered!";
+
+      @Comment("Bedrock registration form")
+      public String REGISTER_FORM_TITLE = "Registration";
+      public String REGISTER_FORM_DESCRIPTION = "Please, enter your password to register.";
+      public String REGISTER_FORM_PASSWORD_PROMPT = "Password";
+      public String REGISTER_FORM_PASSWORD_PLACEHOLDER = "";
+      public String REGISTER_FORM_PASSWORD_CONFIRM_PROMPT = "Repeat password";
+      public String REGISTER_FORM_PASSWORD_CONFIRM_PLACEHOLDER = "";
+      public String REGISTER_FORM_ERROR_DIFFERENT_PASSWORDS = "The entered passwords differ from each other!";
+      public String REGISTER_FORM_ERROR_PASSWORD_TOO_SHORT = "You entered a too short password, use a different one!";
+      public String REGISTER_FORM_ERROR_PASSWORD_TOO_LONG = "You entered a too long password, use a different one!";
+      public String REGISTER_FORM_ERROR_PASSWORD_UNSAFE = "Your password is unsafe, use a different one!";
 
       public String UNREGISTER_SUCCESSFUL = "{PRFX}{NL}&aSuccessfully unregistered!";
       public String UNREGISTER_USAGE = "{PRFX} Usage: &6/unregister <current password> confirm";
@@ -495,6 +514,12 @@ public class Settings extends YamlConfig {
       @Comment("Or if totp-need-pass set to false remove the \"<current password>\" part.")
       public String TOTP_USAGE = "{PRFX} Usage: &6/2fa enable <current password>&f or &6/2fa disable <totp key>&f.";
       public String TOTP_WRONG = "{PRFX} &cWrong 2FA key!";
+      @Comment("Bedrock 2FA form")
+      public String TOTP_FORM_TITLE = "Two-Factor Authentication";
+      public String TOTP_FORM_DESCRIPTION = "Please, enter your 2FA key.";
+      public String TOTP_FORM_CODE_PROMPT = "2FA code";
+      public String TOTP_FORM_CODE_PLACEHOLDER = "";
+      public String TOTP_FORM_ERROR_WRONG_CODE = "Wrong 2FA key!";
       public String TOTP_ALREADY_ENABLED = "{PRFX} &c2FA is already enabled. Disable it using &6/2fa disable <key>&c.";
       public String TOTP_QR = "{PRFX} Click here to open 2FA QR code in browser.";
       public String TOTP_TOKEN = "{PRFX} &aYour 2FA token &7(Click to copy)&a: &6{0}";

--- a/src/main/java/net/elytrium/limboauth/floodgate/FloodgateApiHolder.java
+++ b/src/main/java/net/elytrium/limboauth/floodgate/FloodgateApiHolder.java
@@ -18,7 +18,9 @@
 package net.elytrium.limboauth.floodgate;
 
 import java.util.UUID;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.floodgate.api.FloodgateApi;
+import org.geysermc.floodgate.api.player.FloodgatePlayer;
 
 /**
  * Holder class for optional floodgate feature, we can't inject of optional plugins without holders due to Velocity structure.
@@ -37,5 +39,10 @@ public class FloodgateApiHolder {
 
   public int getPrefixLength() {
     return this.floodgateApi.getPlayerPrefix().length();
+  }
+
+  @Nullable
+  public FloodgatePlayer getPlayer(UUID uuid) {
+    return this.floodgateApi.getPlayer(uuid);
   }
 }

--- a/src/main/java/net/elytrium/limboauth/handler/AuthSessionHandler.java
+++ b/src/main/java/net/elytrium/limboauth/handler/AuthSessionHandler.java
@@ -57,12 +57,15 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.cumulus.CustomForm;
 import org.geysermc.cumulus.response.CustomFormResponse;
 import org.geysermc.floodgate.api.player.FloodgatePlayer;
+import org.slf4j.Logger;
 
 public class AuthSessionHandler implements LimboSessionHandler {
 
   public static final CodeVerifier TOTP_CODE_VERIFIER = new DefaultCodeVerifier(new DefaultCodeGenerator(), new SystemTimeProvider());
   private static final BCrypt.Verifyer HASH_VERIFIER = BCrypt.verifyer();
   private static final BCrypt.Hasher HASHER = BCrypt.withDefaults();
+  private static final long FLOODGATE_FORM_RETRY_DELAY = 500L;
+  private static final int FLOODGATE_FORM_MAX_ATTEMPTS = 5;
 
   private static Component ratelimited;
   private static BossBar.Color bossbarColor;
@@ -141,6 +144,9 @@ public class AuthSessionHandler implements LimboSessionHandler {
   private boolean totpState;
   private String tempPassword;
   private boolean tokenReceived;
+  private int floodgateFormRetryAttempts;
+  @Nullable
+  private ScheduledFuture<?> floodgateFormRetryTask;
 
   public AuthSessionHandler(Dao<RegisteredPlayer, String> playerDao, Player proxyPlayer, LimboAuth plugin,
       @Nullable RegisteredPlayer playerInfo, @Nullable FloodgateApiHolder floodgateApi) {
@@ -374,28 +380,20 @@ public class AuthSessionHandler implements LimboSessionHandler {
       this.authMainTask.cancel(true);
     }
 
+    this.clearFloodgateRetry();
     this.proxyPlayer.hideBossBar(this.bossBar);
     this.plugin.removeAuthenticatingPlayer(this.player.getProxyPlayer().getUsername());
   }
 
   private void sendMessage(boolean sendTitle) {
     if (this.isFloodgatePlayer()) {
-      boolean sent = false;
+      boolean sent;
       if (this.totpState) {
-        sent = this.openTotpForm(null);
-        if (sent && sendTitle && totpTitle != null) {
-          this.proxyPlayer.showTitle(totpTitle);
-        }
+        sent = this.openTotpForm(null, sendTitle);
       } else if (this.playerInfo == null) {
-        sent = this.openRegisterForm(null);
-        if (sent && sendTitle && registerTitle != null) {
-          this.proxyPlayer.showTitle(registerTitle);
-        }
+        sent = this.openRegisterForm(null, sendTitle);
       } else {
-        sent = this.openLoginForm(null);
-        if (sent && sendTitle && loginTitle != null) {
-          this.proxyPlayer.showTitle(loginTitle);
-        }
+        sent = this.openLoginForm(null, sendTitle);
       }
 
       if (sent) {
@@ -425,101 +423,245 @@ public class AuthSessionHandler implements LimboSessionHandler {
     return this.floodgateApi != null && this.floodgateApi.isFloodgatePlayer(this.proxyPlayer.getUniqueId());
   }
 
-  private boolean openRegisterForm(@Nullable String errorMessage) {
-    if (this.floodgateApi == null) {
-      return false;
-    }
-
-    FloodgatePlayer floodgatePlayer = this.floodgateApi.getPlayer(this.proxyPlayer.getUniqueId());
-    if (floodgatePlayer == null) {
-      return false;
-    }
-
-    boolean hasDescription = !registerFormDescription.isEmpty();
-    boolean hasError = errorMessage != null && !errorMessage.isEmpty();
-    CustomForm.Builder builder = CustomForm.builder()
-        .title(registerFormTitle);
-
-    if (hasDescription) {
-      builder.label(registerFormDescription);
-    }
-    if (hasError) {
-      builder.label(errorMessage);
-    }
-
-    builder.input(registerFormPasswordPrompt, registerFormPasswordPlaceholder, "");
-    if (Settings.IMP.MAIN.REGISTER_NEED_REPEAT_PASSWORD) {
-      builder.input(registerFormPasswordConfirmPrompt, registerFormPasswordConfirmPlaceholder, "");
-    }
-
-    final boolean descriptionPresent = hasDescription;
-    final boolean errorPresent = hasError;
-    builder.responseHandler((form, response) -> this.handleRegisterFormResponse(form, response, descriptionPresent, errorPresent));
-
-    return floodgatePlayer.sendForm(builder);
+  private boolean openRegisterForm(@Nullable String errorMessage, boolean sendTitle) {
+    return this.tryOpenFloodgateForm(FloodgateFormType.REGISTER, errorMessage, sendTitle, false);
   }
 
-  private boolean openLoginForm(@Nullable String errorMessage) {
-    if (this.floodgateApi == null) {
-      return false;
-    }
-
-    FloodgatePlayer floodgatePlayer = this.floodgateApi.getPlayer(this.proxyPlayer.getUniqueId());
-    if (floodgatePlayer == null) {
-      return false;
-    }
-
-    boolean hasDescription = !loginFormDescription.isEmpty();
-    boolean hasError = errorMessage != null && !errorMessage.isEmpty();
-    String title = MessageFormat.format(loginFormTitle, this.attempts);
-    CustomForm.Builder builder = CustomForm.builder()
-        .title(title);
-
-    if (hasDescription) {
-      builder.label(MessageFormat.format(loginFormDescription, this.attempts));
-    }
-    if (hasError) {
-      builder.label(errorMessage);
-    }
-
-    builder.input(loginFormPasswordPrompt, loginFormPasswordPlaceholder, "");
-
-    final boolean descriptionPresent = hasDescription;
-    final boolean errorPresent = hasError;
-    builder.responseHandler((form, response) -> this.handleLoginFormResponse(form, response, descriptionPresent, errorPresent));
-
-    return floodgatePlayer.sendForm(builder);
+  private boolean openLoginForm(@Nullable String errorMessage, boolean sendTitle) {
+    return this.tryOpenFloodgateForm(FloodgateFormType.LOGIN, errorMessage, sendTitle, false);
   }
 
-  private boolean openTotpForm(@Nullable String errorMessage) {
+  private boolean openTotpForm(@Nullable String errorMessage, boolean sendTitle) {
+    return this.tryOpenFloodgateForm(FloodgateFormType.TOTP, errorMessage, sendTitle, false);
+  }
+
+  private boolean tryOpenFloodgateForm(FloodgateFormType type, @Nullable String errorMessage, boolean sendTitle, boolean fromRetry) {
+    if (!this.isFloodgatePlayer()) {
+      return false;
+    }
+
+    boolean hasError = errorMessage != null && !errorMessage.isEmpty();
+    CustomForm.Builder builder;
+
+    switch (type) {
+      case REGISTER: {
+        boolean hasDescription = !registerFormDescription.isEmpty();
+        builder = CustomForm.builder()
+            .title(registerFormTitle);
+
+        if (hasDescription) {
+          builder.label(registerFormDescription);
+        }
+        if (hasError) {
+          builder.label(errorMessage);
+        }
+
+        builder.input(registerFormPasswordPrompt, registerFormPasswordPlaceholder, "");
+        if (Settings.IMP.MAIN.REGISTER_NEED_REPEAT_PASSWORD) {
+          builder.input(registerFormPasswordConfirmPrompt, registerFormPasswordConfirmPlaceholder, "");
+        }
+
+        final boolean descriptionPresent = hasDescription;
+        final boolean errorPresent = hasError;
+        builder.responseHandler((form, response) -> this.handleRegisterFormResponse(form, response, descriptionPresent, errorPresent));
+        break;
+      }
+      case LOGIN: {
+        boolean hasDescription = !loginFormDescription.isEmpty();
+        String title = MessageFormat.format(loginFormTitle, this.attempts);
+        builder = CustomForm.builder()
+            .title(title);
+
+        if (hasDescription) {
+          builder.label(MessageFormat.format(loginFormDescription, this.attempts));
+        }
+        if (hasError) {
+          builder.label(errorMessage);
+        }
+
+        builder.input(loginFormPasswordPrompt, loginFormPasswordPlaceholder, "");
+
+        final boolean descriptionPresent = hasDescription;
+        final boolean errorPresent = hasError;
+        builder.responseHandler((form, response) -> this.handleLoginFormResponse(form, response, descriptionPresent, errorPresent));
+        break;
+      }
+      case TOTP: {
+        boolean hasDescription = !totpFormDescription.isEmpty();
+        builder = CustomForm.builder()
+            .title(totpFormTitle);
+
+        if (hasDescription) {
+          builder.label(totpFormDescription);
+        }
+        if (hasError) {
+          builder.label(errorMessage);
+        }
+
+        builder.input(totpFormCodePrompt, totpFormCodePlaceholder, "");
+
+        final boolean descriptionPresent = hasDescription;
+        final boolean errorPresent = hasError;
+        builder.responseHandler((form, response) -> this.handleTotpFormResponse(form, response, descriptionPresent, errorPresent));
+        break;
+      }
+      default:
+        return false;
+    }
+
+    return this.sendFloodgateForm(builder, type, errorMessage, sendTitle, fromRetry);
+  }
+
+  private boolean sendFloodgateForm(
+      CustomForm.Builder builder,
+      FloodgateFormType type,
+      @Nullable String errorMessage,
+      boolean sendTitle,
+      boolean fromRetry
+  ) {
     if (this.floodgateApi == null) {
       return false;
     }
 
     FloodgatePlayer floodgatePlayer = this.floodgateApi.getPlayer(this.proxyPlayer.getUniqueId());
     if (floodgatePlayer == null) {
+      this.logFloodgateWarn(
+          "Unable to open Floodgate {} form for {}: player not available (error: {}, attempt: {}, fromRetry: {})",
+          type.getDisplayName(),
+          this.proxyPlayer.getUsername(),
+          errorMessage != null ? errorMessage : "none",
+          this.floodgateFormRetryAttempts,
+          fromRetry
+      );
+      if (!fromRetry) {
+        this.scheduleFloodgateFormRetry(type, errorMessage, sendTitle);
+      }
       return false;
     }
 
-    boolean hasDescription = !totpFormDescription.isEmpty();
-    boolean hasError = errorMessage != null && !errorMessage.isEmpty();
-    CustomForm.Builder builder = CustomForm.builder()
-        .title(totpFormTitle);
-
-    if (hasDescription) {
-      builder.label(totpFormDescription);
+    boolean sent = floodgatePlayer.sendForm(builder);
+    if (sent) {
+      int attempts = this.floodgateFormRetryAttempts;
+      if (attempts > 0) {
+        this.logFloodgateInfo(
+            "Sent Floodgate {} form to {} after {} retries",
+            type.getDisplayName(),
+            this.proxyPlayer.getUsername(),
+            attempts
+        );
+      } else {
+        this.logFloodgateInfo(
+            "Sent Floodgate {} form to {}",
+            type.getDisplayName(),
+            this.proxyPlayer.getUsername()
+        );
+      }
+      if (sendTitle) {
+        this.showFloodgateTitle(type);
+      }
+      this.clearFloodgateRetry();
+    } else {
+      this.logFloodgateWarn(
+          "Floodgate API rejected {} form for {} (error: {}, attempt: {}, fromRetry: {})",
+          type.getDisplayName(),
+          this.proxyPlayer.getUsername(),
+          errorMessage != null ? errorMessage : "none",
+          this.floodgateFormRetryAttempts,
+          fromRetry
+      );
+      if (!fromRetry) {
+        this.scheduleFloodgateFormRetry(type, errorMessage, sendTitle);
+      }
     }
-    if (hasError) {
-      builder.label(errorMessage);
+
+    return sent;
+  }
+
+  private void showFloodgateTitle(FloodgateFormType type) {
+    switch (type) {
+      case REGISTER:
+        if (registerTitle != null) {
+          this.proxyPlayer.showTitle(registerTitle);
+        }
+        break;
+      case LOGIN:
+        if (loginTitle != null) {
+          this.proxyPlayer.showTitle(loginTitle);
+        }
+        break;
+      case TOTP:
+        if (totpTitle != null) {
+          this.proxyPlayer.showTitle(totpTitle);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  private void scheduleFloodgateFormRetry(FloodgateFormType type, @Nullable String errorMessage, boolean sendTitle) {
+    if (this.player == null) {
+      return;
+    }
+    if (this.floodgateFormRetryTask != null && !this.floodgateFormRetryTask.isDone()) {
+      return;
     }
 
-    builder.input(totpFormCodePrompt, totpFormCodePlaceholder, "");
+    int nextAttempt = this.floodgateFormRetryAttempts + 1;
+    if (nextAttempt > FLOODGATE_FORM_MAX_ATTEMPTS) {
+      this.logFloodgateWarn(
+          "Giving up on Floodgate {} form for {} after {} attempts",
+          type.getDisplayName(),
+          this.proxyPlayer.getUsername(),
+          this.floodgateFormRetryAttempts
+      );
+      this.clearFloodgateRetry();
+      return;
+    }
 
-    final boolean descriptionPresent = hasDescription;
-    final boolean errorPresent = hasError;
-    builder.responseHandler((form, response) -> this.handleTotpFormResponse(form, response, descriptionPresent, errorPresent));
+    this.logFloodgateInfo(
+        "Scheduling Floodgate {} form retry for {} (attempt {}/{})",
+        type.getDisplayName(),
+        this.proxyPlayer.getUsername(),
+        nextAttempt,
+        FLOODGATE_FORM_MAX_ATTEMPTS
+    );
 
-    return floodgatePlayer.sendForm(builder);
+    this.floodgateFormRetryTask = this.player.getScheduledExecutor().schedule(() -> {
+      this.floodgateFormRetryTask = null;
+      if (!this.isFloodgatePlayer()) {
+        this.clearFloodgateRetry();
+        return;
+      }
+
+      this.floodgateFormRetryAttempts = nextAttempt;
+      boolean sent = this.tryOpenFloodgateForm(type, errorMessage, sendTitle, true);
+      if (!sent) {
+        this.scheduleFloodgateFormRetry(type, errorMessage, sendTitle);
+      }
+    }, FLOODGATE_FORM_RETRY_DELAY, TimeUnit.MILLISECONDS);
+  }
+
+  private void clearFloodgateRetry() {
+    this.floodgateFormRetryAttempts = 0;
+    if (this.floodgateFormRetryTask != null) {
+      this.floodgateFormRetryTask.cancel(false);
+      this.floodgateFormRetryTask = null;
+    }
+  }
+
+  private void logFloodgateInfo(String message, Object... arguments) {
+    Logger logger = LimboAuth.getLogger();
+    if (logger != null) {
+      logger.info(message, arguments);
+    }
+  }
+
+  private void logFloodgateWarn(String message, Object... arguments) {
+    Logger logger = LimboAuth.getLogger();
+    if (logger != null) {
+      logger.warn(message, arguments);
+    }
   }
 
   private void handleRegisterFormResponse(CustomForm form, String response, boolean hasDescription, boolean hasError) {
@@ -549,7 +691,7 @@ public class AuthSessionHandler implements LimboSessionHandler {
     }
 
     if (Settings.IMP.MAIN.REGISTER_NEED_REPEAT_PASSWORD && !password.equals(repeatPassword)) {
-      if (!this.openRegisterForm(registerFormErrorDifferentPasswords)) {
+      if (!this.openRegisterForm(registerFormErrorDifferentPasswords, false)) {
         this.proxyPlayer.sendMessage(registerDifferentPasswords);
       }
       return;
@@ -557,19 +699,19 @@ public class AuthSessionHandler implements LimboSessionHandler {
 
     int length = password.length();
     if (length > Settings.IMP.MAIN.MAX_PASSWORD_LENGTH) {
-      if (!this.openRegisterForm(registerFormErrorPasswordTooLong)) {
+      if (!this.openRegisterForm(registerFormErrorPasswordTooLong, false)) {
         this.proxyPlayer.sendMessage(registerPasswordTooLong);
       }
       return;
     }
     if (length < Settings.IMP.MAIN.MIN_PASSWORD_LENGTH) {
-      if (!this.openRegisterForm(registerFormErrorPasswordTooShort)) {
+      if (!this.openRegisterForm(registerFormErrorPasswordTooShort, false)) {
         this.proxyPlayer.sendMessage(registerPasswordTooShort);
       }
       return;
     }
     if (Settings.IMP.MAIN.CHECK_PASSWORD_STRENGTH && this.plugin.getUnsafePasswords().contains(password)) {
-      if (!this.openRegisterForm(registerFormErrorPasswordUnsafe)) {
+      if (!this.openRegisterForm(registerFormErrorPasswordUnsafe, false)) {
         this.proxyPlayer.sendMessage(registerPasswordUnsafe);
       }
       return;
@@ -635,7 +777,7 @@ public class AuthSessionHandler implements LimboSessionHandler {
     if (--this.attempts != 0) {
       this.checkBruteforceAttempts();
       String errorMessage = MessageFormat.format(loginFormErrorWrongPassword, this.attempts);
-      if (!this.openLoginForm(errorMessage)) {
+      if (!this.openLoginForm(errorMessage, false)) {
         this.proxyPlayer.sendMessage(loginWrongPassword[this.attempts - 1]);
       }
     } else {
@@ -674,7 +816,7 @@ public class AuthSessionHandler implements LimboSessionHandler {
     }
 
     this.checkBruteforceAttempts();
-    if (!this.openTotpForm(totpFormErrorWrongCode)) {
+    if (!this.openTotpForm(totpFormErrorWrongCode, false)) {
       this.proxyPlayer.sendMessage(totp);
     }
   }
@@ -756,6 +898,7 @@ public class AuthSessionHandler implements LimboSessionHandler {
     }
 
     this.plugin.cacheAuthUser(this.proxyPlayer);
+    this.clearFloodgateRetry();
     this.player.disconnect();
   }
 
@@ -909,6 +1052,23 @@ public class AuthSessionHandler implements LimboSessionHandler {
     return HASHER.hashToString(Settings.IMP.MAIN.BCRYPT_COST, password.toCharArray());
   }
 
+
+  private enum FloodgateFormType {
+
+    REGISTER("registration"),
+    LOGIN("login"),
+    TOTP("totp");
+
+    private final String displayName;
+
+    FloodgateFormType(String displayName) {
+      this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+      return this.displayName;
+    }
+  }
 
   private enum Command {
 

--- a/src/main/java/net/elytrium/limboauth/handler/AuthSessionHandler.java
+++ b/src/main/java/net/elytrium/limboauth/handler/AuthSessionHandler.java
@@ -46,6 +46,7 @@ import net.elytrium.limboauth.Settings;
 import net.elytrium.limboauth.event.PostAuthorizationEvent;
 import net.elytrium.limboauth.event.PostRegisterEvent;
 import net.elytrium.limboauth.event.TaskEvent;
+import net.elytrium.limboauth.floodgate.FloodgateApiHolder;
 import net.elytrium.limboauth.migration.MigrationHash;
 import net.elytrium.limboauth.model.RegisteredPlayer;
 import net.elytrium.limboauth.model.SQLRuntimeException;
@@ -53,6 +54,9 @@ import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.title.Title;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.geysermc.cumulus.CustomForm;
+import org.geysermc.cumulus.response.CustomFormResponse;
+import org.geysermc.floodgate.api.player.FloodgatePlayer;
 
 public class AuthSessionHandler implements LimboSessionHandler {
 
@@ -91,10 +95,32 @@ public class AuthSessionHandler implements LimboSessionHandler {
   private static Title loginSuccessfulTitle;
   @Nullable
   private static MigrationHash migrationHash;
+  private static String registerFormTitle;
+  private static String registerFormDescription;
+  private static String registerFormPasswordPrompt;
+  private static String registerFormPasswordPlaceholder;
+  private static String registerFormPasswordConfirmPrompt;
+  private static String registerFormPasswordConfirmPlaceholder;
+  private static String registerFormErrorDifferentPasswords;
+  private static String registerFormErrorPasswordTooLong;
+  private static String registerFormErrorPasswordTooShort;
+  private static String registerFormErrorPasswordUnsafe;
+  private static String loginFormTitle;
+  private static String loginFormDescription;
+  private static String loginFormPasswordPrompt;
+  private static String loginFormPasswordPlaceholder;
+  private static String loginFormErrorWrongPassword;
+  private static String totpFormTitle;
+  private static String totpFormDescription;
+  private static String totpFormCodePrompt;
+  private static String totpFormCodePlaceholder;
+  private static String totpFormErrorWrongCode;
 
   private final Dao<RegisteredPlayer, String> playerDao;
   private final Player proxyPlayer;
   private final LimboAuth plugin;
+  @Nullable
+  private final FloodgateApiHolder floodgateApi;
 
   private final long joinTime = System.currentTimeMillis();
   private final BossBar bossBar = BossBar.bossBar(
@@ -116,11 +142,13 @@ public class AuthSessionHandler implements LimboSessionHandler {
   private String tempPassword;
   private boolean tokenReceived;
 
-  public AuthSessionHandler(Dao<RegisteredPlayer, String> playerDao, Player proxyPlayer, LimboAuth plugin, @Nullable RegisteredPlayer playerInfo) {
+  public AuthSessionHandler(Dao<RegisteredPlayer, String> playerDao, Player proxyPlayer, LimboAuth plugin,
+      @Nullable RegisteredPlayer playerInfo, @Nullable FloodgateApiHolder floodgateApi) {
     this.playerDao = playerDao;
     this.proxyPlayer = proxyPlayer;
     this.plugin = plugin;
     this.playerInfo = playerInfo;
+    this.floodgateApi = floodgateApi;
   }
 
   @Override
@@ -351,6 +379,30 @@ public class AuthSessionHandler implements LimboSessionHandler {
   }
 
   private void sendMessage(boolean sendTitle) {
+    if (this.isFloodgatePlayer()) {
+      boolean sent = false;
+      if (this.totpState) {
+        sent = this.openTotpForm(null);
+        if (sent && sendTitle && totpTitle != null) {
+          this.proxyPlayer.showTitle(totpTitle);
+        }
+      } else if (this.playerInfo == null) {
+        sent = this.openRegisterForm(null);
+        if (sent && sendTitle && registerTitle != null) {
+          this.proxyPlayer.showTitle(registerTitle);
+        }
+      } else {
+        sent = this.openLoginForm(null);
+        if (sent && sendTitle && loginTitle != null) {
+          this.proxyPlayer.showTitle(loginTitle);
+        }
+      }
+
+      if (sent) {
+        return;
+      }
+    }
+
     if (this.totpState) {
       this.proxyPlayer.sendMessage(totp);
       if (sendTitle && totpTitle != null) {
@@ -366,6 +418,264 @@ public class AuthSessionHandler implements LimboSessionHandler {
       if (sendTitle && loginTitle != null) {
         this.proxyPlayer.showTitle(loginTitle);
       }
+    }
+  }
+
+  private boolean isFloodgatePlayer() {
+    return this.floodgateApi != null && this.floodgateApi.isFloodgatePlayer(this.proxyPlayer.getUniqueId());
+  }
+
+  private boolean openRegisterForm(@Nullable String errorMessage) {
+    if (this.floodgateApi == null) {
+      return false;
+    }
+
+    FloodgatePlayer floodgatePlayer = this.floodgateApi.getPlayer(this.proxyPlayer.getUniqueId());
+    if (floodgatePlayer == null) {
+      return false;
+    }
+
+    boolean hasDescription = !registerFormDescription.isEmpty();
+    boolean hasError = errorMessage != null && !errorMessage.isEmpty();
+    CustomForm.Builder builder = CustomForm.builder()
+        .title(registerFormTitle);
+
+    if (hasDescription) {
+      builder.label(registerFormDescription);
+    }
+    if (hasError) {
+      builder.label(errorMessage);
+    }
+
+    builder.input(registerFormPasswordPrompt, registerFormPasswordPlaceholder, "");
+    if (Settings.IMP.MAIN.REGISTER_NEED_REPEAT_PASSWORD) {
+      builder.input(registerFormPasswordConfirmPrompt, registerFormPasswordConfirmPlaceholder, "");
+    }
+
+    final boolean descriptionPresent = hasDescription;
+    final boolean errorPresent = hasError;
+    builder.responseHandler((form, response) -> this.handleRegisterFormResponse(form, response, descriptionPresent, errorPresent));
+
+    return floodgatePlayer.sendForm(builder);
+  }
+
+  private boolean openLoginForm(@Nullable String errorMessage) {
+    if (this.floodgateApi == null) {
+      return false;
+    }
+
+    FloodgatePlayer floodgatePlayer = this.floodgateApi.getPlayer(this.proxyPlayer.getUniqueId());
+    if (floodgatePlayer == null) {
+      return false;
+    }
+
+    boolean hasDescription = !loginFormDescription.isEmpty();
+    boolean hasError = errorMessage != null && !errorMessage.isEmpty();
+    String title = MessageFormat.format(loginFormTitle, this.attempts);
+    CustomForm.Builder builder = CustomForm.builder()
+        .title(title);
+
+    if (hasDescription) {
+      builder.label(MessageFormat.format(loginFormDescription, this.attempts));
+    }
+    if (hasError) {
+      builder.label(errorMessage);
+    }
+
+    builder.input(loginFormPasswordPrompt, loginFormPasswordPlaceholder, "");
+
+    final boolean descriptionPresent = hasDescription;
+    final boolean errorPresent = hasError;
+    builder.responseHandler((form, response) -> this.handleLoginFormResponse(form, response, descriptionPresent, errorPresent));
+
+    return floodgatePlayer.sendForm(builder);
+  }
+
+  private boolean openTotpForm(@Nullable String errorMessage) {
+    if (this.floodgateApi == null) {
+      return false;
+    }
+
+    FloodgatePlayer floodgatePlayer = this.floodgateApi.getPlayer(this.proxyPlayer.getUniqueId());
+    if (floodgatePlayer == null) {
+      return false;
+    }
+
+    boolean hasDescription = !totpFormDescription.isEmpty();
+    boolean hasError = errorMessage != null && !errorMessage.isEmpty();
+    CustomForm.Builder builder = CustomForm.builder()
+        .title(totpFormTitle);
+
+    if (hasDescription) {
+      builder.label(totpFormDescription);
+    }
+    if (hasError) {
+      builder.label(errorMessage);
+    }
+
+    builder.input(totpFormCodePrompt, totpFormCodePlaceholder, "");
+
+    final boolean descriptionPresent = hasDescription;
+    final boolean errorPresent = hasError;
+    builder.responseHandler((form, response) -> this.handleTotpFormResponse(form, response, descriptionPresent, errorPresent));
+
+    return floodgatePlayer.sendForm(builder);
+  }
+
+  private void handleRegisterFormResponse(CustomForm form, String response, boolean hasDescription, boolean hasError) {
+    CustomFormResponse formResponse = form.parseResponse(response);
+    if (!formResponse.isCorrect()) {
+      this.sendMessage(false);
+      return;
+    }
+
+    int index = 0;
+    if (hasDescription) {
+      ++index;
+    }
+    if (hasError) {
+      ++index;
+    }
+
+    String password = formResponse.getInput(index);
+    if (password == null) {
+      password = "";
+    }
+
+    String repeatPassword = password;
+    if (Settings.IMP.MAIN.REGISTER_NEED_REPEAT_PASSWORD) {
+      String repeatInput = formResponse.getInput(index + 1);
+      repeatPassword = repeatInput != null ? repeatInput : "";
+    }
+
+    if (Settings.IMP.MAIN.REGISTER_NEED_REPEAT_PASSWORD && !password.equals(repeatPassword)) {
+      if (!this.openRegisterForm(registerFormErrorDifferentPasswords)) {
+        this.proxyPlayer.sendMessage(registerDifferentPasswords);
+      }
+      return;
+    }
+
+    int length = password.length();
+    if (length > Settings.IMP.MAIN.MAX_PASSWORD_LENGTH) {
+      if (!this.openRegisterForm(registerFormErrorPasswordTooLong)) {
+        this.proxyPlayer.sendMessage(registerPasswordTooLong);
+      }
+      return;
+    }
+    if (length < Settings.IMP.MAIN.MIN_PASSWORD_LENGTH) {
+      if (!this.openRegisterForm(registerFormErrorPasswordTooShort)) {
+        this.proxyPlayer.sendMessage(registerPasswordTooShort);
+      }
+      return;
+    }
+    if (Settings.IMP.MAIN.CHECK_PASSWORD_STRENGTH && this.plugin.getUnsafePasswords().contains(password)) {
+      if (!this.openRegisterForm(registerFormErrorPasswordUnsafe)) {
+        this.proxyPlayer.sendMessage(registerPasswordUnsafe);
+      }
+      return;
+    }
+
+    this.saveTempPassword(password);
+    RegisteredPlayer registeredPlayer = new RegisteredPlayer(this.proxyPlayer).setPassword(password);
+
+    try {
+      this.playerDao.create(registeredPlayer);
+      this.playerInfo = registeredPlayer;
+    } catch (SQLException e) {
+      this.proxyPlayer.disconnect(databaseErrorKick);
+      throw new SQLRuntimeException(e);
+    }
+
+    this.proxyPlayer.sendMessage(registerSuccessful);
+    if (registerSuccessfulTitle != null) {
+      this.proxyPlayer.showTitle(registerSuccessfulTitle);
+    }
+
+    this.plugin.getServer().getEventManager()
+        .fire(new PostRegisterEvent(this::finishAuth, this.player, this.playerInfo, this.tempPassword))
+        .thenAcceptAsync(this::finishAuth);
+  }
+
+  private void handleLoginFormResponse(CustomForm form, String response, boolean hasDescription, boolean hasError) {
+    if (this.playerInfo == null) {
+      return;
+    }
+
+    CustomFormResponse formResponse = form.parseResponse(response);
+    if (!formResponse.isCorrect()) {
+      this.sendMessage(false);
+      return;
+    }
+
+    int index = 0;
+    if (hasDescription) {
+      ++index;
+    }
+    if (hasError) {
+      ++index;
+    }
+
+    String password = formResponse.getInput(index);
+    if (password == null) {
+      password = "";
+    }
+
+    this.saveTempPassword(password);
+
+    if (password.length() > 0 && checkPassword(password, this.playerInfo, this.playerDao)) {
+      if (this.playerInfo.getTotpToken().isEmpty()) {
+        this.finishLogin();
+      } else {
+        this.totpState = true;
+        this.sendMessage(true);
+      }
+      return;
+    }
+
+    if (--this.attempts != 0) {
+      this.checkBruteforceAttempts();
+      String errorMessage = MessageFormat.format(loginFormErrorWrongPassword, this.attempts);
+      if (!this.openLoginForm(errorMessage)) {
+        this.proxyPlayer.sendMessage(loginWrongPassword[this.attempts - 1]);
+      }
+    } else {
+      this.proxyPlayer.disconnect(loginWrongPasswordKick);
+    }
+  }
+
+  private void handleTotpFormResponse(CustomForm form, String response, boolean hasDescription, boolean hasError) {
+    if (this.playerInfo == null) {
+      return;
+    }
+
+    CustomFormResponse formResponse = form.parseResponse(response);
+    if (!formResponse.isCorrect()) {
+      this.sendMessage(false);
+      return;
+    }
+
+    int index = 0;
+    if (hasDescription) {
+      ++index;
+    }
+    if (hasError) {
+      ++index;
+    }
+
+    String code = formResponse.getInput(index);
+    if (code == null) {
+      code = "";
+    }
+    code = code.trim();
+
+    if (TOTP_CODE_VERIFIER.isValidCode(this.playerInfo.getTotpToken(), code)) {
+      this.finishLogin();
+      return;
+    }
+
+    this.checkBruteforceAttempts();
+    if (!this.openTotpForm(totpFormErrorWrongCode)) {
+      this.proxyPlayer.sendMessage(totp);
     }
   }
 
@@ -522,6 +832,27 @@ public class AuthSessionHandler implements LimboSessionHandler {
           Settings.IMP.MAIN.CRACKED_TITLE_SETTINGS.toTimes()
       );
     }
+
+    registerFormTitle = Settings.IMP.MAIN.STRINGS.REGISTER_FORM_TITLE;
+    registerFormDescription = Settings.IMP.MAIN.STRINGS.REGISTER_FORM_DESCRIPTION;
+    registerFormPasswordPrompt = Settings.IMP.MAIN.STRINGS.REGISTER_FORM_PASSWORD_PROMPT;
+    registerFormPasswordPlaceholder = Settings.IMP.MAIN.STRINGS.REGISTER_FORM_PASSWORD_PLACEHOLDER;
+    registerFormPasswordConfirmPrompt = Settings.IMP.MAIN.STRINGS.REGISTER_FORM_PASSWORD_CONFIRM_PROMPT;
+    registerFormPasswordConfirmPlaceholder = Settings.IMP.MAIN.STRINGS.REGISTER_FORM_PASSWORD_CONFIRM_PLACEHOLDER;
+    registerFormErrorDifferentPasswords = Settings.IMP.MAIN.STRINGS.REGISTER_FORM_ERROR_DIFFERENT_PASSWORDS;
+    registerFormErrorPasswordTooLong = Settings.IMP.MAIN.STRINGS.REGISTER_FORM_ERROR_PASSWORD_TOO_LONG;
+    registerFormErrorPasswordTooShort = Settings.IMP.MAIN.STRINGS.REGISTER_FORM_ERROR_PASSWORD_TOO_SHORT;
+    registerFormErrorPasswordUnsafe = Settings.IMP.MAIN.STRINGS.REGISTER_FORM_ERROR_PASSWORD_UNSAFE;
+    loginFormTitle = Settings.IMP.MAIN.STRINGS.LOGIN_FORM_TITLE;
+    loginFormDescription = Settings.IMP.MAIN.STRINGS.LOGIN_FORM_DESCRIPTION;
+    loginFormPasswordPrompt = Settings.IMP.MAIN.STRINGS.LOGIN_FORM_PASSWORD_PROMPT;
+    loginFormPasswordPlaceholder = Settings.IMP.MAIN.STRINGS.LOGIN_FORM_PASSWORD_PLACEHOLDER;
+    loginFormErrorWrongPassword = Settings.IMP.MAIN.STRINGS.LOGIN_FORM_ERROR_WRONG_PASSWORD;
+    totpFormTitle = Settings.IMP.MAIN.STRINGS.TOTP_FORM_TITLE;
+    totpFormDescription = Settings.IMP.MAIN.STRINGS.TOTP_FORM_DESCRIPTION;
+    totpFormCodePrompt = Settings.IMP.MAIN.STRINGS.TOTP_FORM_CODE_PROMPT;
+    totpFormCodePlaceholder = Settings.IMP.MAIN.STRINGS.TOTP_FORM_CODE_PLACEHOLDER;
+    totpFormErrorWrongCode = Settings.IMP.MAIN.STRINGS.TOTP_FORM_ERROR_WRONG_CODE;
 
     migrationHash = Settings.IMP.MAIN.MIGRATION_HASH;
   }


### PR DESCRIPTION
## Summary
- add Floodgate-aware registration, login and TOTP forms for Bedrock players
- expose Floodgate player access in the API holder and pass it to the session handler
- extend configuration with strings for form titles, prompts and errors

## Testing
- ./gradlew check

------
https://chatgpt.com/codex/tasks/task_e_68c9110dedf4833293b007524d0038d3